### PR TITLE
fix: update description in get_bytes function to PNG, rather than JPEG

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -140,7 +140,7 @@ impl PhotonImage {
         res_base64
     }
 
-    /// Convert the PhotonImage to raw bytes. Returns JPEG.
+    /// Convert the PhotonImage to raw bytes. Returns PNG.
     pub fn get_bytes(&self) -> Vec<u8> {
         let mut img = helpers::dyn_image_from_raw(self);
         img = ImageRgba8(img.to_rgba8());


### PR DESCRIPTION
Updates the description for get bytes 